### PR TITLE
CoinDenomExtension

### DIFF
--- a/TerraSharp/Core/CoinDenomExtension.cs
+++ b/TerraSharp/Core/CoinDenomExtension.cs
@@ -9,29 +9,21 @@ namespace TerraSharp.Core
 {
     public static class CoinDenomExtension
     {
-        public static CoinDenomOptions GetBlockchainOptions(this CoinDenoms @this)
+        /// <summary>
+        /// GetCoinDenomOptions
+        /// </summary>
+        /// <param name="this"></param>
+        /// <returns></returns>
+        public static CoinDenomOptions GetCoinDenomOptions(string @this)
         {
             // Get Member Info
-            var memberInfo = typeof(CoinDenoms).GetMember(@this.ToString()).FirstOrDefault();
+            var memberInfo = typeof(CoinDenoms).GetMember(@this.ToString().ToUpper()).FirstOrDefault();
             if (memberInfo == null) return null;
 
             // Get Options
             var options = (CoinDenomOptions)Attribute.GetCustomAttribute(memberInfo, typeof(CoinDenomOptions));
             return options;
         }
-        public static string GetDescription(this Enum CoinDenoms)
-        {
-            Type genericEnumType = CoinDenoms.GetType();
-            MemberInfo[] memberInfo = genericEnumType.GetMember(CoinDenoms.ToString());
-            if ((memberInfo != null && memberInfo.Length > 0))
-            {
-                var _Attribs = memberInfo[0].GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
-                if ((_Attribs != null && _Attribs.Count() > 0))
-                {
-                    return ((System.ComponentModel.DescriptionAttribute)_Attribs.ElementAt(0)).Description;
-                }
-            }
-            return CoinDenoms.ToString();
-        }
+       
     }
 }

--- a/TerraSharp/Core/CoinDenomExtension.cs
+++ b/TerraSharp/Core/CoinDenomExtension.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Terra.Microsoft.Client.Core.Constants;
+
+namespace TerraSharp.Core
+{
+    public static class CoinDenomExtension
+    {
+        public static CoinDenomOptions GetBlockchainOptions(this CoinDenoms @this)
+        {
+            // Get Member Info
+            var memberInfo = typeof(CoinDenoms).GetMember(@this.ToString()).FirstOrDefault();
+            if (memberInfo == null) return null;
+
+            // Get Options
+            var options = (CoinDenomOptions)Attribute.GetCustomAttribute(memberInfo, typeof(CoinDenomOptions));
+            return options;
+        }
+        public static string GetDescription(this Enum CoinDenoms)
+        {
+            Type genericEnumType = CoinDenoms.GetType();
+            MemberInfo[] memberInfo = genericEnumType.GetMember(CoinDenoms.ToString());
+            if ((memberInfo != null && memberInfo.Length > 0))
+            {
+                var _Attribs = memberInfo[0].GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
+                if ((_Attribs != null && _Attribs.Count() > 0))
+                {
+                    return ((System.ComponentModel.DescriptionAttribute)_Attribs.ElementAt(0)).Description;
+                }
+            }
+            return CoinDenoms.ToString();
+        }
+    }
+}

--- a/TerraSharp/Core/CoinDenomOptions.cs
+++ b/TerraSharp/Core/CoinDenomOptions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TerraSharp.Core
+{
+    public class CoinDenomOptions : Attribute
+    {
+        public string ImageUrl { get; set; }
+        public bool MainnetSupport { get; set; }
+        public bool TestNetSupport { get; set; }
+        public double Decimals { get; set; }
+        public CoinDenomOptions(string imageUrl, bool mainnetSupport, bool testNetSupport, double decimals) 
+        {
+            ImageUrl= imageUrl;
+            MainnetSupport= mainnetSupport;
+            TestNetSupport= testNetSupport;
+            Decimals= decimals;
+        }
+    }
+}

--- a/TerraSharp/Core/CoinDenomOptions.cs
+++ b/TerraSharp/Core/CoinDenomOptions.cs
@@ -6,12 +6,23 @@ namespace TerraSharp.Core
 {
     public class CoinDenomOptions : Attribute
     {
+        public string Description { get; set; }
         public string ImageUrl { get; set; }
         public bool MainnetSupport { get; set; }
         public bool TestNetSupport { get; set; }
         public double Decimals { get; set; }
-        public CoinDenomOptions(string imageUrl, bool mainnetSupport, bool testNetSupport, double decimals) 
+
+        /// <summary>
+        /// CoinDenomOptions
+        /// </summary>
+        /// <param name="description"></param>
+        /// <param name="imageUrl"></param>
+        /// <param name="mainnetSupport"></param>
+        /// <param name="testNetSupport"></param>
+        /// <param name="decimals"></param>
+        public CoinDenomOptions(string description,string imageUrl, bool mainnetSupport, bool testNetSupport, double decimals) 
         {
+            Description = description;
             ImageUrl= imageUrl;
             MainnetSupport= mainnetSupport;
             TestNetSupport= testNetSupport;

--- a/TerraSharp/Core/Constants/CoinDenoms.cs
+++ b/TerraSharp/Core/Constants/CoinDenoms.cs
@@ -76,4 +76,5 @@ namespace Terra.Microsoft.Client.Core.Constants
         public const string UCAD = "ucad";
 
     }
+
 }

--- a/TerraSharp/Core/Constants/CoinDenoms.cs
+++ b/TerraSharp/Core/Constants/CoinDenoms.cs
@@ -5,74 +5,51 @@ namespace Terra.Microsoft.Client.Core.Constants
 {
     public class CoinDenoms
     {
-        [Description("TerraLuna")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/LUNC.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraLuna", imageUrl: "https://assets.terra.money/icon/svg/LUNC.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string ULUNA = "uluna";
-        [Description("TerraUSD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/UST.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraUSD", imageUrl: "https://assets.terra.money/icon/svg/Terra/UST.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UUSD = "uusd";
-        [Description("TerraIDR")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/IDT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraIDR", imageUrl: "https://assets.terra.money/icon/svg/Terra/IDT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UIDR = "uidr";
-        [Description("TerraKRW")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/KRT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraKRW", imageUrl: "https://assets.terra.money/icon/svg/Terra/KRT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UKRW = "ukrw";
-        [Description("TerraMNT")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/MNT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraMNT", imageUrl: "https://assets.terra.money/icon/svg/Terra/MNT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UMNT = "umnt";
-        [Description("TerraPHP")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/PHT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraPHP", imageUrl: "https://assets.terra.money/icon/svg/Terra/PHT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UPHP = "uphp";
-        [Description("TerraSDR")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SDT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraSDR", imageUrl: "https://assets.terra.money/icon/svg/Terra/SDT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string USDR = "usdr";
-        [Description("TerraEUR")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/EUT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraEUR", imageUrl: "https://assets.terra.money/icon/svg/Terra/EUT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UEUR = "ueur";
-        [Description("TerraCNY")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CNT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraCNY", imageUrl: "https://assets.terra.money/icon/svg/Terra/CNT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UCNY = "ucny";
-        [Description("TerraJPY")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/JPT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraJPY", imageUrl: "https://assets.terra.money/icon/svg/Terra/JPT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UJPY = "ujpy";
-        [Description("TerraGBP")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/GBT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraGBP", imageUrl: "https://assets.terra.money/icon/svg/Terra/GBT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UGBP = "ugbp";
-        [Description("TerraINR")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/INT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraINR", imageUrl: "https://assets.terra.money/icon/svg/Terra/INT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UINR = "uinr";
-        [Description("TerraCHF")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CHT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraCHF", imageUrl: "https://assets.terra.money/icon/svg/Terra/CHT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UCHF = "uchf";
-        [Description("TerraAUD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/AUT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraAUD", imageUrl: "https://assets.terra.money/icon/svg/Terra/AUT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UAUD = "uaud";
-        [Description("TerraSGD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SGT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraSGD", imageUrl: "https://assets.terra.money/icon/svg/Terra/SGT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string USGD = "usgd";
-        [Description("TerraTHB")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/THT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraTHB", imageUrl: "https://assets.terra.money/icon/svg/Terra/THT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UTHB = "uthb";
-        [Description("TerraSEK")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SET.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraSEK", imageUrl: "https://assets.terra.money/icon/svg/Terra/SET.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string USEK = "usek";
-        [Description("TerraNOK")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/NOT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraNOK", imageUrl: "https://assets.terra.money/icon/svg/Terra/NOT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UNOK = "unok";
-        [Description("TerraDKK")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/DKT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraDKK", imageUrl: "https://assets.terra.money/icon/svg/Terra/DKT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UDKK = "udkk";
-        [Description("TerraHKD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/HKT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraHKD", imageUrl: "https://assets.terra.money/icon/svg/Terra/HKT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UHKD = "uhkd";
-        [Description("TerraMYR")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/MYT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraMYR", imageUrl: "https://assets.terra.money/icon/svg/Terra/MYT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UMYR = "umyr";
-        [Description("TerraTWD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/TWT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraTWD", imageUrl: "https://assets.terra.money/icon/svg/Terra/TWT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UTWD = "utwd";
-        [Description("TerraCAD")]
-        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CAT.svg", true, true, 6)]
+        [CoinDenomOptions(description: "TerraCAD", imageUrl: "https://assets.terra.money/icon/svg/Terra/CAT.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
         public const string UCAD = "ucad";
 
     }

--- a/TerraSharp/Core/Constants/CoinDenoms.cs
+++ b/TerraSharp/Core/Constants/CoinDenoms.cs
@@ -1,29 +1,79 @@
-﻿namespace Terra.Microsoft.Client.Core.Constants
+﻿using System.ComponentModel;
+using TerraSharp.Core;
+
+namespace Terra.Microsoft.Client.Core.Constants
 {
     public class CoinDenoms
     {
+        [Description("TerraLuna")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/LUNC.svg", true, true, 6)]
         public const string ULUNA = "uluna";
+        [Description("TerraUSD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/UST.svg", true, true, 6)]
         public const string UUSD = "uusd";
+        [Description("TerraIDR")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/IDT.svg", true, true, 6)]
         public const string UIDR = "uidr";
+        [Description("TerraKRW")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/KRT.svg", true, true, 6)]
         public const string UKRW = "ukrw";
+        [Description("TerraMNT")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/MNT.svg", true, true, 6)]
         public const string UMNT = "umnt";
+        [Description("TerraPHP")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/PHT.svg", true, true, 6)]
         public const string UPHP = "uphp";
+        [Description("TerraSDR")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SDT.svg", true, true, 6)]
         public const string USDR = "usdr";
+        [Description("TerraEUR")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/EUT.svg", true, true, 6)]
         public const string UEUR = "ueur";
+        [Description("TerraCNY")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CNT.svg", true, true, 6)]
         public const string UCNY = "ucny";
+        [Description("TerraJPY")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/JPT.svg", true, true, 6)]
         public const string UJPY = "ujpy";
+        [Description("TerraGBP")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/GBT.svg", true, true, 6)]
         public const string UGBP = "ugbp";
+        [Description("TerraINR")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/INT.svg", true, true, 6)]
         public const string UINR = "uinr";
+        [Description("TerraCHF")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CHT.svg", true, true, 6)]
         public const string UCHF = "uchf";
+        [Description("TerraAUD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/AUT.svg", true, true, 6)]
         public const string UAUD = "uaud";
+        [Description("TerraSGD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SGT.svg", true, true, 6)]
         public const string USGD = "usgd";
+        [Description("TerraTHB")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/THT.svg", true, true, 6)]
         public const string UTHB = "uthb";
+        [Description("TerraSEK")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/SET.svg", true, true, 6)]
         public const string USEK = "usek";
+        [Description("TerraNOK")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/NOT.svg", true, true, 6)]
         public const string UNOK = "unok";
+        [Description("TerraDKK")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/DKT.svg", true, true, 6)]
         public const string UDKK = "udkk";
+        [Description("TerraHKD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/HKT.svg", true, true, 6)]
         public const string UHKD = "uhkd";
+        [Description("TerraMYR")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/MYT.svg", true, true, 6)]
         public const string UMYR = "umyr";
+        [Description("TerraTWD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/TWT.svg", true, true, 6)]
         public const string UTWD = "utwd";
+        [Description("TerraCAD")]
+        [CoinDenomOptions("https://assets.terra.money/icon/svg/Terra/CAT.svg", true, true, 6)]
         public const string UCAD = "ucad";
+
     }
 }


### PR DESCRIPTION
Example:
`
var coin = CoinDenoms.ULUNA;
var options = CoinDenomExtension.GetCoinDenomOptions(coin.denom);

var image = options.ImageUrl;
var description = options.Description

`
constant:
`
[CoinDenomOptions(description: "TerraLuna", imageUrl: "https://assets.terra.money/icon/svg/LUNC.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
        public const string ULUNA = "uluna";
        [CoinDenomOptions(description: "TerraUSD", imageUrl: "https://assets.terra.money/icon/svg/Terra/UST.svg", mainnetSupport: true, testNetSupport: true, decimals: 6)]
        public const string UUSD = "uusd";
`